### PR TITLE
BUGFIX(loki): index start date was too old

### DIFF
--- a/templates/config.yml.j2
+++ b/templates/config.yml.j2
@@ -19,7 +19,7 @@ ingester:
 
 schema_config:
   configs:
-  - from: 2018-04-15
+  - from: 2020-05-01
     store: boltdb
     object_store: filesystem
     schema: v11


### PR DESCRIPTION
 ##### SUMMARY

this would cause some trouble and loki was shutting down without any
warnings

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION