### PR TITLE
BUGFIX/MINOR(loki): fix `openio_bind_mgmt_address` typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ An Ansible role for install loki. Specifically, the responsibilities of this rol
 | :---       | :---    | :---             |
 | `openio_loki_namespace` | `"{{ namespace \| d('OPENIO') }}"` | OpenIO Namespace |
 | `openio_loki_maintenance_mode` | `"{{ openio_maintenance_mode \| d(false) }}"` | Maintenance mode |
-| `openio_loki_bind_address` | `"{{ openio_mgmt_bind_address \| d(ansible_default_ipv4.address) }}"` | Binding IP address |
+| `openio_loki_bind_address` | `"{{ openio_bind_mgmt_address \| d(ansible_default_ipv4.address) }}"` | Binding IP address |
 | `openio_loki_bind_port` | `6900` | Binding port |
 | `openio_loki_grpc_bind_address` | `127.0.0.1` | GRPC binding IP address |
 | `openio_loki_grpc_bind_port` | `6903` | GRPC binding port |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 openio_loki_namespace: "{{ namespace | d('OPENIO') }}"
 openio_loki_maintenance_mode: "{{ openio_maintenance_mode | d(false) }}"
 
-openio_loki_bind_address: "{{ openio_mgmt_bind_address | d(ansible_default_ipv4.address) }}"
+openio_loki_bind_address: "{{ openio_bind_mgmt_address | d(ansible_default_ipv4.address) }}"
 openio_loki_bind_port: 6902
 openio_loki_grpc_bind_address: "127.0.0.1"
 openio_loki_grpc_bind_port: 6903


### PR DESCRIPTION
 ##### SUMMARY
`openio_bind_mgmt_address` instead of `openio_mgmt_bind_address`

 ##### IMPACT
#Describe the impact of the change (N/A for no impact)
N/A

 ##### ADDITIONAL INFORMATION