### PR TITLE
CHANGE(loki): remove `oio-` prefix to service_type

### DIFF
--- a/docker-tests/checks.bats
+++ b/docker-tests/checks.bats
@@ -24,13 +24,13 @@ run_only_test() {
 }
 
 @test 'Loki config file exists' {
-  run bash -c "docker exec -ti ${SUT_ID} cat /etc/oio/sds/TRAVIS/oio-loki-0/config.yml"
+  run bash -c "docker exec -ti ${SUT_ID} cat /etc/oio/sds/TRAVIS/loki-0/config.yml"
   echo "output: "$output
   [[ "${status}" -eq "0" ]]
 }
 
 @test 'Loki conf file is valid YAML' {
-    run bash -c "docker exec -ti ${SUT_ID} find /etc/oio/sds/TRAVIS/oio-loki-0/ -name \*.yml -exec python -c \
+    run bash -c "docker exec -ti ${SUT_ID} find /etc/oio/sds/TRAVIS/loki-0/ -name \*.yml -exec python -c \
     'import sys,yaml; yaml.load(open(sys.argv[1]).read(), Loader=yaml.SafeLoader);' {} \;"
     echo "output: "$output
     [[ "${output}" -eq "" ]]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - include_role:
     name: openio-service
   vars:
-    openio_service_type: "oio-loki"
+    openio_service_type: "loki"
     openio_service_namespace: "{{ openio_loki_namespace }}"
     openio_service_maintenance_mode: "{{ openio_loki_maintenance_mode }}"
     openio_service_packages:


### PR DESCRIPTION
 ##### SUMMARY
no need to have `oio-` in front of service name for monitoring

 ##### IMPACT
service name and path changes

 ##### ADDITIONAL INFORMATION